### PR TITLE
28 feature add newly created habits to a side on the device

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,14 @@ https://XXXXXXXXXX.execute-api.eu-north-1.amazonaws.com/habits/{userId}
 
 **Adding a new habit for a user**
 
-https://XXXXXXXXXX.execute-api.eu-north-1.amazonaws.com/createHabit/{userId}/{deviceId}/{habitName}/{habitType}
+https://XXXXXXXXXX.execute-api.eu-north-1.amazonaws.com/createHabit/{userId}/{deviceId}/{habitName}/{habitType}/{deviceSide}
 
 - "XXXXXXXXXX" is the API ID, which can be found in table for APIs in the API Gateway console. The API name is HabitStorageHTTP. Ask you local Backend expert if you dont fin the ID
 - {userId} is the id of the user you want to add a new habit to. Currently, we only have one user with id 0
 - {deviceId} is the id of the device the user wants to track this habit with
 - {habitName} is the name of the habit the user want to track
 - {habitType} is the type tracking the user want to do for the habit. Currently we only support "count" and "time"
+- {deviceSide} is the side of the device you want to connect to. This is 0-indexed and works with all numbers from 0 to 11
 - The "{}" brackets should not be included in the url, just write 0/TestDK/treehugging/time
 
 ### configure-shadow-api

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 ## For non-backend devs
 
+### General info
+
+Each of the stacks below has its own API-id. The ids can be found in the AWS API Gateway console. Ask your local backend dev if you can find the API id, and he will happily help you.
+
 ### habit-storage
 
 This stack uses API Gateway, DynamoDB and Lambda to get and update the users habit. Format for different HTTP routes below

--- a/configure-shadow-api/lambda/getShadow.mjs
+++ b/configure-shadow-api/lambda/getShadow.mjs
@@ -2,10 +2,7 @@ import { IoTDataPlaneClient, GetThingShadowCommand } from '@aws-sdk/client-iot-d
 
 export const handler = async (event) => {
   // client for requesting shadow
-  const client = new IoTDataPlaneClient({
-    //logger: console,
-    endpoint: 'https://a2aclgd4nh1dkk-ats.iot.eu-north-1.amazonaws.com',
-  })
+  const client = new IoTDataPlaneClient({})
   // Create empty response
   let response = ''
 

--- a/configure-shadow-api/lambda/updateShadow.mjs
+++ b/configure-shadow-api/lambda/updateShadow.mjs
@@ -4,10 +4,7 @@ import { IoTDataPlaneClient, UpdateThingShadowCommand } from '@aws-sdk/client-io
 
 export const handler = async (event) => {
   // client for requesting shadow
-  const client = new IoTDataPlaneClient({
-    // logger: console,
-    endpoint: 'https://a2aclgd4nh1dkk-ats.iot.eu-north-1.amazonaws.com',
-  })
+  const client = new IoTDataPlaneClient({})
 
   // Create empty response
   let response = ''

--- a/habit-storage/lambda/createHabit.mjs
+++ b/habit-storage/lambda/createHabit.mjs
@@ -32,7 +32,7 @@ export const handler = async (event) => {
     }
 
     // Validates if the deviceside exists on the device
-    if (Number(event.pathParameters.deviceSide) < 0 || Number(event.pathParameters.deviceSide) > 12) {
+    if (Number(event.pathParameters.deviceSide) < 0 || Number(event.pathParameters.deviceSide) > 11) {
       body = 'invalid deviceSide. Must be a number between 0 and 12'
       return body
     }

--- a/habit-storage/lib/habit-storage-stack.ts
+++ b/habit-storage/lib/habit-storage-stack.ts
@@ -13,7 +13,7 @@ export class HabitStorageStack extends cdk.Stack {
     //Creating API, and configures CORS to allow GET methods
     const httpApi = new apigwv2.HttpApi(this, 'HabitStorageHTTP', {
       corsPreflight: {
-        allowMethods: [apigwv2.CorsHttpMethod.GET, apigwv2.CorsHttpMethod.POST],
+        allowMethods: [apigwv2.CorsHttpMethod.GET, apigwv2.CorsHttpMethod.PUT],
       },
     })
 
@@ -38,8 +38,8 @@ export class HabitStorageStack extends cdk.Stack {
     })
 
     httpApi.addRoutes({
-      path: '/createHabit/{userId}/{deviceId}/{habitName}/{habitType}',
-      methods: [apigwv2.HttpMethod.GET],
+      path: '/createHabit/{userId}/{deviceId}/{habitName}/{habitType}/{deviceSide}',
+      methods: [apigwv2.HttpMethod.GET, apigwv2.HttpMethod.PUT],
       integration: createHabitLambdaIntegration,
     })
   }


### PR DESCRIPTION
## Related issues
Issue #28

## Summary

This makes the api for creating habits also add the habit to a specified side on the firmware device. This is needed because frontend didnt like our previous solutions

## Changes Made

- Added functionality to createHabit.mjs to add a habitId to a specified side on the firmware device
- Gave createHabit.mjs access to modify IoT shadows
- Updated README to cover the new changes

## Checklist

- [X] I have added comments to code where needed
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have tested that there are no new bugs
- [ ] I have added tests that prove my fix is effective or that my feature works (Optional before testing is discovered)
