### PR TITLE
[#86] feat: Make policies independent of our aws id

### DIFF
--- a/configure-shadow-api/bin/configure-shadow-api.ts
+++ b/configure-shadow-api/bin/configure-shadow-api.ts
@@ -1,25 +1,21 @@
 #!/usr/bin/env node
-import "source-map-support/register";
-import * as cdk from "aws-cdk-lib";
-import { ConfigureShadowApiStack } from "../lib/configure-shadow-api-stack";
+import 'source-map-support/register'
+import * as cdk from 'aws-cdk-lib'
+import { ConfigureShadowApiStack } from '../lib/configure-shadow-api-stack'
 
-const app = new cdk.App();
-new ConfigureShadowApiStack(app, "ConfigureShadowApiStack", {
-  env: {
-    account: process.env.CDK_DEFAULT_ACCOUNT,
-    region: process.env.CDK_DEFAULT_REGION,
-  },
+const app = new cdk.App()
+new ConfigureShadowApiStack(app, 'ConfigureShadowApiStack', {
   /* If you don't specify 'env', this stack will be environment-agnostic.
    * Account/Region-dependent features and context lookups will not work,
    * but a single synthesized template can be deployed anywhere. */
 
   /* Uncomment the next line to specialize this stack for the AWS Account
    * and Region that are implied by the current CLI configuration. */
-  // env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
+  env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
 
   /* Uncomment the next line if you know exactly what Account and Region you
    * want to deploy the stack to. */
   // env: { account: '123456789012', region: 'us-east-1' },
 
   /* For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html */
-});
+})

--- a/configure-shadow-api/lib/configure-shadow-api-stack.ts
+++ b/configure-shadow-api/lib/configure-shadow-api-stack.ts
@@ -5,11 +5,6 @@ import * as lambda from 'aws-cdk-lib/aws-lambda'
 import { HttpLambdaIntegration } from 'aws-cdk-lib/aws-apigatewayv2-integrations'
 import * as iam from 'aws-cdk-lib/aws-iam'
 
-/**
- * TODO
- * - create seperate roles and policies for postShadowHandler and getShadowHandler
- */
-
 export class ConfigureShadowApiStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props)
@@ -27,7 +22,7 @@ export class ConfigureShadowApiStack extends cdk.Stack {
         statements: [
           new iam.PolicyStatement({
             actions: ['iot:GetThingShadow', 'iot:UpdateThingShadow'],
-            resources: ['arn:aws:iot:eu-north-1:339713040007:thing/*'],
+            resources: [`arn:aws:iot:${props?.env?.region}:${props?.env?.region}:thing/*`],
           }),
         ],
       })

--- a/habit-event-storage/bin/habit-event-storage.ts
+++ b/habit-event-storage/bin/habit-event-storage.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
-import 'source-map-support/register';
-import * as cdk from 'aws-cdk-lib';
-import { HabitEventStorageStack } from '../lib/habit-event-storage-stack';
+import 'source-map-support/register'
+import * as cdk from 'aws-cdk-lib'
+import { HabitEventStorageStack } from '../lib/habit-event-storage-stack'
 
-const app = new cdk.App();
+const app = new cdk.App()
 new HabitEventStorageStack(app, 'HabitEventStorageStack', {
   /* If you don't specify 'env', this stack will be environment-agnostic.
    * Account/Region-dependent features and context lookups will not work,
@@ -11,11 +11,11 @@ new HabitEventStorageStack(app, 'HabitEventStorageStack', {
 
   /* Uncomment the next line to specialize this stack for the AWS Account
    * and Region that are implied by the current CLI configuration. */
-  // env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
+  env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
 
   /* Uncomment the next line if you know exactly what Account and Region you
    * want to deploy the stack to. */
   // env: { account: '123456789012', region: 'us-east-1' },
 
   /* For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html */
-});
+})

--- a/habit-event-storage/lib/habit-event-storage-stack.ts
+++ b/habit-event-storage/lib/habit-event-storage-stack.ts
@@ -112,7 +112,7 @@ export class HabitEventStorageStack extends cdk.Stack {
             sid: 'UserDataTableInteractions',
             effect: aws_iam.Effect.ALLOW,
             actions: ['dynamodb:Query'],
-            resources: ['arn:aws:dynamodb:eu-north-1:339713040007:table/UserDataTable/*'],
+            resources: [`arn:aws:dynamodb:${props?.env?.region}:${props?.env?.account}:table/UserDataTable/*`],
           }),
         ],
       }

--- a/habit-storage/bin/habit-storage.ts
+++ b/habit-storage/bin/habit-storage.ts
@@ -10,7 +10,7 @@ new HabitStorageStack(app, 'HabitStorageStack', {
    * but a single synthesized template can be deployed anywhere. */
   /* Uncomment the next line to specialize this stack for the AWS Account
    * and Region that are implied by the current CLI configuration. */
-  // env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
+  env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
   /* Uncomment the next line if you know exactly what Account and Region you
    * want to deploy the stack to. */
   // env: { account: '123456789012', region: 'us-east-1' },

--- a/habit-storage/lib/habit-storage-stack.ts
+++ b/habit-storage/lib/habit-storage-stack.ts
@@ -8,7 +8,7 @@ export class HabitStorageStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props)
     //Creating HabitStorage construct
-    const habitStorage = new HabitStorage(this, 'HabitStorage')
+    const habitStorage = new HabitStorage(this, 'HabitStorage', props)
 
     //Creating API, and configures CORS to allow GET methods
     const httpApi = new apigwv2.HttpApi(this, 'HabitStorageHTTP', {

--- a/habit-storage/lib/habitStorage.ts
+++ b/habit-storage/lib/habitStorage.ts
@@ -2,10 +2,7 @@ import * as dynamodb from 'aws-cdk-lib/aws-dynamodb'
 import * as lambda from 'aws-cdk-lib/aws-lambda'
 import { Construct } from 'constructs'
 import * as iam from 'aws-cdk-lib/aws-iam'
-
-/**
- * This file contains the table for storing diffrent habits, and a handler for interracting with it
- */
+import * as cdk from 'aws-cdk-lib'
 
 export class HabitStorage extends Construct {
   // Making handler and table public for all
@@ -15,7 +12,7 @@ export class HabitStorage extends Construct {
   public readonly editHabitHandler: lambda.Function
   public readonly deleteHabitHandler: lambda.Function
 
-  constructor(scope: Construct, id: string) {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id)
 
     // Creating role for createHabit
@@ -31,7 +28,7 @@ export class HabitStorage extends Construct {
         statements: [
           new iam.PolicyStatement({
             actions: ['iot:GetThingShadow', 'iot:UpdateThingShadow'],
-            resources: ['arn:aws:iot:eu-north-1:339713040007:thing/*'],
+            resources: [`arn:aws:iot:${props?.env?.region}:${props?.env?.account}:thing/*`],
           }),
           new iam.PolicyStatement({
             actions: ['logs:CreateLogGroup', 'logs:CreateLogStream', 'logs:PutLogEvents', 'logs:DescribeLogStreams'],
@@ -39,7 +36,7 @@ export class HabitStorage extends Construct {
           }),
           new iam.PolicyStatement({
             actions: ['dynamodb:*'],
-            resources: ['arn:aws:dynamodb:eu-north-1:339713040007:*'],
+            resources: [`arn:aws:dynamodb:${props?.env?.region}:${props?.env?.account}:*`],
           }),
         ],
       }),

--- a/user-pool/bin/user-pool.ts
+++ b/user-pool/bin/user-pool.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
-import 'source-map-support/register';
-import * as cdk from 'aws-cdk-lib';
-import { UserPoolStack } from '../lib/user-pool-stack';
+import 'source-map-support/register'
+import * as cdk from 'aws-cdk-lib'
+import { UserPoolStack } from '../lib/user-pool-stack'
 
-const app = new cdk.App();
+const app = new cdk.App()
 new UserPoolStack(app, 'UserPoolStack', {
   /* If you don't specify 'env', this stack will be environment-agnostic.
    * Account/Region-dependent features and context lookups will not work,
@@ -11,11 +11,11 @@ new UserPoolStack(app, 'UserPoolStack', {
 
   /* Uncomment the next line to specialize this stack for the AWS Account
    * and Region that are implied by the current CLI configuration. */
-  // env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
+  env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
 
   /* Uncomment the next line if you know exactly what Account and Region you
    * want to deploy the stack to. */
   // env: { account: '123456789012', region: 'us-east-1' },
 
   /* For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html */
-});
+})

--- a/user-pool/lib/user-pool-stack.ts
+++ b/user-pool/lib/user-pool-stack.ts
@@ -55,7 +55,7 @@ export class UserPoolStack extends cdk.Stack {
         statements: [
           new iam.PolicyStatement({
             actions: ['dynamodb:*'],
-            resources: ['arn:aws:dynamodb:eu-north-1:339713040007:*'],
+            resources: [`arn:aws:dynamodb:${props?.env?.region}:${props?.env?.account}:*`],
           }),
         ],
       }),
@@ -79,6 +79,9 @@ export class UserPoolStack extends cdk.Stack {
       runtime: lambda.Runtime.NODEJS_20_X,
       handler: 'login.handler',
       code: lambda.Code.fromAsset('lambda'),
+      environment: {
+        USERPOOL_ID: habitTrackerUserPoolClient.userPoolClientId,
+      },
     })
 
     const verifyEmailFunction = new lambda.Function(this, 'VerifyEmailFunction', {


### PR DESCRIPTION
## Related issues
Issue #86

## Summary

This will change the resource policy to adapt to whoever is deploying our stack. It used to be ties to our specific account id, but not anymore!

## Changes Made

- Changed resources to be attached to the default id of the deployment

## Checklist

- [X] I have added comments to code where needed
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have tested that there are no new bugs
- [X] I have added tests that prove my fix is effective or that my feature works (Optional before testing is discovered)
